### PR TITLE
fix: adapt theme to Firefox 152/153 variable renames + reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Hi! I'm [d0sse](https://github.com/d0sse) and this is Minimalist Mac - Safari-like - Firefox theme.
 
-> 🚀 **UPDATED FOR FIREFOX 151**
+> 🚀 **UPDATED FOR FIREFOX 153**
 
 ## Features
 
@@ -60,23 +60,49 @@ To start using MacFox, follow these steps:
     widget.macos.titlebar-blend-mode.behind-window
     ```
 
-5. Go to the following url address `about:support`.
-6. Find "Profile Folder" section in the "Application Basics" list and copy the path (defined below as `$path`).
-7. Open `terminal.app` and type:
+5. If you want to disable the tab hover preview (the thumbnail card shown when hovering a tab), set this pref to `false`:
+
+    ```text
+    browser.tabs.hoverPreview.enabled
+    ```
+
+Then install the theme using **either** the quick script (recommended) or the manual steps below.
+
+#### Option A — Install script (recommended)
+
+1. Clone the repo anywhere and run the installer:
+
+    ```bash
+    git clone git@github.com:d0sse/macFox-theme.git
+    cd macFox-theme
+    ./install.sh
+    ```
+
+    The script auto-detects your default Firefox profile and copies the theme's
+    CSS files into its `chrome` folder. To target a specific profile, pass its
+    path: `./install.sh /path/to/profile`.
+
+2. Apply `about:blank` for new windows and new tabs.
+3. Fully restart Firefox (`Cmd+Q`, then reopen) to apply changes.
+
+#### Option B — Manual
+
+1. Go to the following url address `about:support`.
+2. Find "Profile Folder" section in the "Application Basics" list and copy the path (defined below as `$path`).
+3. Open `terminal.app` and type:
 
     ```bash
     cd $path
     ```
 
-8. Type in the following command:
+4. Type in the following command:
 
     ```bash
     git clone git@github.com:d0sse/macFox-theme.git chrome
     ```
 
-9. Apply `about blank` for New windows and new tabs.
-
-10. Restart Firefox to apply changes.
+5. Apply `about:blank` for new windows and new tabs.
+6. Fully restart Firefox (`Cmd+Q`, then reopen) to apply changes.
 
 ## Privacy & Telemetry
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# macFox-theme installer
+# Copies the theme's CSS files into your Firefox profile's `chrome` folder.
+#
+# Usage:
+#   ./install.sh                 # auto-detect the default Firefox profile
+#   ./install.sh /path/to/profile  # install into a specific profile folder
+#
+# macOS only. After running, fully restart Firefox to apply changes.
+
+set -euo pipefail
+
+# CSS files that make up the theme (everything else in the repo is docs/assets).
+CSS_FILES=(
+	userChrome.css
+	userContent.css
+	variables.css
+	navbar.css
+	urlbar.css
+	icons.css
+	tabbar.css
+)
+
+# Resolve the directory this script lives in (the repo root).
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+FIREFOX_DIR="${HOME}/Library/Application Support/Firefox"
+
+die() { printf 'Error: %s\n' "$1" >&2; exit 1; }
+
+# --------------------------------------------------------------------------
+# Determine the target profile folder.
+# --------------------------------------------------------------------------
+profile=""
+
+if [[ $# -ge 1 ]]; then
+	# Explicit profile path supplied.
+	profile="$1"
+else
+	[[ -d "$FIREFOX_DIR" ]] || die "Firefox directory not found at $FIREFOX_DIR"
+	ini="${FIREFOX_DIR}/profiles.ini"
+
+	if [[ -f "$ini" ]]; then
+		# Prefer the [Install*] section's Default (the profile Firefox launches).
+		rel="$(awk -F= '/^\[Install/{f=1} f&&/^Default=/{print $2; exit}' "$ini" || true)"
+		# Fall back to a [Profile*] entry marked Default=1.
+		if [[ -z "$rel" ]]; then
+			rel="$(awk -F= '
+				/^\[Profile/{p=""; d=0}
+				/^Path=/{p=$2}
+				/^Default=1/{d=1}
+				d&&p{print p; exit}' "$ini" || true)"
+		fi
+		[[ -n "$rel" ]] && profile="${FIREFOX_DIR}/${rel}"
+	fi
+
+	# Last resort: glob for a *.default-release folder.
+	if [[ -z "$profile" ]]; then
+		profile="$(find "${FIREFOX_DIR}/Profiles" -maxdepth 1 -name '*.default-release' 2>/dev/null | head -n1 || true)"
+	fi
+fi
+
+[[ -n "$profile" ]] || die "Could not determine a Firefox profile. Pass one explicitly: ./install.sh /path/to/profile"
+[[ -d "$profile" ]] || die "Profile folder does not exist: $profile"
+
+# --------------------------------------------------------------------------
+# Copy the CSS into <profile>/chrome/.
+# --------------------------------------------------------------------------
+chrome_dir="${profile}/chrome"
+mkdir -p "$chrome_dir"
+
+printf 'Installing macFox-theme into:\n  %s\n\n' "$chrome_dir"
+for f in "${CSS_FILES[@]}"; do
+	src="${SCRIPT_DIR}/${f}"
+	[[ -f "$src" ]] || die "Missing theme file: $src"
+	cp "$src" "$chrome_dir/"
+	printf '  copied %s\n' "$f"
+done
+
+cat <<'EOF'
+
+Done. Next steps:
+  1. In about:config, ensure these are set to true:
+       toolkit.legacyUserProfileCustomizations.stylesheets
+       svg.context-properties.content.enabled
+       browser.tabs.allow_transparent_browser
+       layout.css.color-mix.enabled
+       browser.theme.native-theme
+  2. Fully restart Firefox (Cmd+Q, then reopen) to apply the theme.
+EOF

--- a/navbar.css
+++ b/navbar.css
@@ -1,8 +1,10 @@
 #nav-bar {
-	height: 42px !important;
+	height: 44px !important;
 	border: 0 !important;
 	padding-left: 8px !important;
 	padding-right: 8px !important;
+	padding-top: 4px !important;
+	padding-bottom: 4px !important;
 }
 
 #main-window[inFullscreen] #nav-bar {
@@ -17,13 +19,7 @@
 	background-color: var(--background-color-primary) !important;
 }
 
-/* Toolbar button look */
-:root {
-	--button-hover-bgcolor: var(--hover-color-primary) !important;
-	--toolbarbutton-inner-padding: 6px !important;
-	--toolbarbutton-active-background: var(--hover-color-primary) !important;
-}
-
+/* Toolbar button look (button colors/padding live in variables.css) */
 #nav-bar .toolbarbutton-1 image,
 #nav-bar .toolbarbutton-1 .toolbarbutton-badge-stack {
 	fill: var(--tint-color-primary) !important;

--- a/tabbar.css
+++ b/tabbar.css
@@ -1,17 +1,4 @@
-:root {
-	/* Base color is always whatever the theme/extension gives us */
-	--tab-base-color: var(--toolbar-bgcolor);
-
-	/* Overlays = transparent black or white depending on text contrast */
-	--tab-overlay-neutral: color-mix(in srgb, var(--toolbar-color) 5%, transparent);
-	--tab-overlay-hover: color-mix(in srgb, var(--toolbar-color) 25%, transparent);
-	--tab-overlay-active: color-mix(in srgb, var(--toolbar-color) 20%, transparent);
-
-	/* Final colors you can use */
-	--tab-color: var(--tab-overlay-neutral);
-	--tab-hover-color: var(--tab-overlay-hover);
-	--tab-active-color: var(--tab-overlay-active);
-}
+/* Tab colors and sizing live in variables.css */
 
 /* Sets tab appearance */
 .tab-background {

--- a/urlbar.css
+++ b/urlbar.css
@@ -1,24 +1,11 @@
-:root {
-	--url-border-color: rgba(0, 0, 0, 0.15);
-	--url-placeholder-color: rgba(0, 0, 0, 0.5);
-	--url-bar-outline-color: AccentColor;
-	--toolbar-field-focus-color: AccentColor;
-}
-
-@media (prefers-color-scheme: dark) {
-	:root {
-		--url-border-color: rgba(255, 255, 255, 0.15);
-		--url-placeholder-color: rgba(255, 255, 255, 0.5);
-	}
-}
-
+/* URL bar colors live in variables.css */
 
 #urlbar-container {
 	max-width: 50% !important;
 }
 
 #urlbar {
-	min-height: 32px !important;
+	min-height: var(--urlbar-height) !important;
 	font-size: 13px !important;
 	margin-bottom: 2px !important;
 }
@@ -33,19 +20,14 @@
 	text-align: center !important;
 }
 
-/* Urlbar icons look */
+/* Urlbar icons look (corner radii handled by the nested-radius rule below) */
 .urlbar-page-action {
-	height: 24px !important;
-	border-radius: 5px !important;
+	height: var(--urlbar-control-height) !important;
 }
 
 .urlbar-page-action image {
 	margin-top: -2px !important;
 	transform: scale(0.9, 0.9) !important;
-}
-
-.identity-box-button {
-	border-radius: 4px !important;
 }
 
 .identity-box-button image {
@@ -92,7 +74,7 @@
 }
 
 #star-button-box {
-	margin: 2px !important;
+	margin: var(--urlbar-inner-margin) !important;
 }
 
 #star-button[starred="true"] {
@@ -103,14 +85,17 @@
 	background-color: transparent !important;
 }
 
+/* Nested corner radius: controls inset inside the urlbar keep corners
+   concentric with the urlbar's rounded edge (radius = outer - margin). */
 .identity-box-button,
-.urlbar-page-action {
-	border-radius: var(--border-circle) !important;
+.urlbar-page-action,
+#star-button-box,
+.urlbar-revert-button {
+	border-radius: var(--urlbar-inner-radius) !important;
 }
 
 .urlbar-revert-button {
 	margin-right: 4px;
-	border-radius: var(--border-circle) !important;
 }
 
 #urlbar[open] .urlbarView-row {

--- a/userChrome.css
+++ b/userChrome.css
@@ -1,47 +1,10 @@
 /* Firefox macOS style */
+@import "variables.css";
 @import "navbar.css";
 @import "urlbar.css";
 @import "icons.css";
 @import "tabbar.css";
 
-
-:root {
-    --accent: AccentColor;
-    --lwt-accent-color: AccentColor;
-    --tab-loading-fill: AccentColor !important;
-    --button-primary-bgcolor: AccentColor !important;
-    --border-circle: 8px;
-    --border-big: 8px;
-    --border-big-2: 8px;
-    --tab-min-height: 32px !important;
-    --tab-min-width: 66px !important;
-    --fullscreen-color: #fafafa;
-    --urlbar-solid-bg: #f2f2f2;
-    --urlbar-base-color: var(--toolbar-bgcolor);
-    --urlbar-overlay-active: color-mix(in srgb, var(--toolbar-color) 5%, transparent);
-    --urlbar-overlay-non-active: color-mix(in srgb, var(--toolbar-color) 9%, transparent);
-}
-
-/* Enable Safari-like Tahoe UI when `userChrome.tahoeUI.enabled` is true in about:config */
-@media -moz-pref("userChrome.tahoeUI.enabled") {
-    :root {
-        --border-circle: 99px;
-        --border-big: 20px;
-        --border-big-2: 16px;
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --fullscreen-color: #2a2a2a;
-        --urlbar-solid-bg: #2b2b2b;
-    }
-}
-
-/* If Firefox/ATBC provides a dynamic color, override the fallback */
-:root {
-    --urlbar-solid-bg: var(--toolbar-field-background-color, var(--urlbar-solid-bg));
-}
 
 /* Active Window Styles */
 #navigator-toolbox,
@@ -79,7 +42,7 @@
 }
 
 #trust-icon-container {
-    border-radius: var(--border-circle) !important;
+    border-radius: var(--urlbar-inner-radius) !important;
     margin-left: 0 !important;
 }
 
@@ -107,8 +70,8 @@
 }
 
 #nav-bar {
-    padding-top: 3px !important;
-    padding-bottom: 2px !important;
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
 }
 
 #TabsToolbar {
@@ -121,7 +84,7 @@
 :root[sizemode="fullscreen"] #PersonalToolbar,
 :root[sizemode="fullscreen"] #TabsToolbar,
 :root[sizemode="fullscreen"] #nav-bar {
-    background-color: var(--toolbar-bgcolor, var(--fullscreen-color)) !important;
+    background-color: var(--mf-toolbar-bg, var(--fullscreen-color)) !important;
 }
 
 #browser {
@@ -140,13 +103,13 @@ browser {
 }
 
 .urlbar-page-action {
-    margin: 2px !important;
-    border-radius: var(--border-circle) !important;
+    margin: var(--urlbar-inner-margin) !important;
+    border-radius: var(--urlbar-inner-radius) !important;
     opacity: 0.3;
 }
 
 .urlbar-page-action:hover {
-    margin: 2px !important;
+    margin: var(--urlbar-inner-margin) !important;
     opacity: 1.0;
 }
 
@@ -159,8 +122,8 @@ browser {
 }
 
 .identity-box-button {
-    margin: 2px !important;
-    border-radius: var(--border-circle) !important;
+    margin: var(--urlbar-inner-margin) !important;
+    border-radius: var(--urlbar-inner-radius) !important;
     opacity: 0.3;
 }
 
@@ -169,8 +132,8 @@ browser {
 }
 
 #urlbar-searchmode-switcher {
-    margin: 3px !important;
-    border-radius: var(--border-circle) !important;
+    margin: var(--urlbar-inner-margin) !important;
+    border-radius: var(--urlbar-inner-radius) !important;
     opacity: 0.3;
 }
 

--- a/userContent.css
+++ b/userContent.css
@@ -52,7 +52,11 @@ body.pageCharlie {
 	.nova-outer-wrapper .customize-menu,
 	.nova-outer-wrapper .logo-and-wordmark-wrapper,
 	.nova-outer-wrapper .main-button,
-	.nova-outer-wrapper .personalize-button {
+	.nova-outer-wrapper .personalize-button,
+	/* Non-Nova New Tab: the bottom-right "personalize / customize" pencil */
+	.personalizeButtonWrapper,
+	.personalize-button,
+	.customize-menu {
 		display: none !important;
 	}
 

--- a/variables.css
+++ b/variables.css
@@ -1,0 +1,126 @@
+/* ==========================================================================
+   macFox – Theme variables
+   --------------------------------------------------------------------------
+   Every custom property the theme defines lives here, so the component
+   stylesheets (navbar / urlbar / tabbar / icons) contain rules only.
+   This file is imported first by userChrome.css.
+   ========================================================================== */
+
+:root {
+	/* ----------------------------------------------------------------------
+	   Firefox compatibility aliases
+	   Firefox 152 renamed the toolbar custom properties:
+	     --toolbar-bgcolor -> --toolbar-background-color
+	     --toolbar-color   -> --toolbar-text-color
+	   These aliases resolve to the new name first and fall back to the legacy
+	   name, so the rest of the theme can reference a single pair regardless of
+	   the Firefox version (151 and earlier vs 152+).
+	   ---------------------------------------------------------------------- */
+	--mf-toolbar-bg: var(--toolbar-background-color, var(--toolbar-bgcolor));
+	--mf-toolbar-fg: var(--toolbar-text-color, var(--toolbar-color));
+
+	/* ----------------------------------------------------------------------
+	   Accent color (system macOS accent, exposed to Firefox internals)
+	   ---------------------------------------------------------------------- */
+	--accent: AccentColor;
+	--lwt-accent-color: AccentColor;
+	--tab-loading-fill: AccentColor !important;
+	--button-primary-bgcolor: AccentColor !important;
+
+	/* ----------------------------------------------------------------------
+	   Corner radii (overridden by the Tahoe UI block below)
+	   ---------------------------------------------------------------------- */
+	--border-circle: 8px;
+	--border-big: 8px;
+	--border-big-2: 8px;
+
+	/* ----------------------------------------------------------------------
+	   Tab sizing
+	   ---------------------------------------------------------------------- */
+	--tab-min-height: 32px !important;
+	--tab-min-width: 66px !important;
+
+	/* ----------------------------------------------------------------------
+	   Tab background overlays
+	   Base color is whatever the theme/extension provides; overlays are a
+	   translucent tint of the toolbar text color so tabs read correctly on
+	   both light and dark backgrounds.
+	   ---------------------------------------------------------------------- */
+	--tab-base-color: var(--mf-toolbar-bg);
+	--tab-overlay-neutral: color-mix(in srgb, var(--mf-toolbar-fg) 5%, transparent);
+	--tab-overlay-hover: color-mix(in srgb, var(--mf-toolbar-fg) 25%, transparent);
+	--tab-overlay-active: color-mix(in srgb, var(--mf-toolbar-fg) 20%, transparent);
+	--tab-color: var(--tab-overlay-neutral);
+	--tab-hover-color: var(--tab-overlay-hover);
+	--tab-active-color: var(--tab-overlay-active);
+
+	/* ----------------------------------------------------------------------
+	   Toolbar buttons
+	   Firefox 152 moved these to the --toolbarbutton-<prop>-<state> scheme.
+	   The new names are set for 152+, the legacy names for 151 and earlier.
+	   Hover/active colors come from ATBC's --hover-color-primary.
+	   ---------------------------------------------------------------------- */
+	--toolbarbutton-background-color-hover: var(--hover-color-primary) !important;
+	--toolbarbutton-background-color-active: var(--hover-color-primary) !important;
+	--toolbarbutton-padding-inner: 6px !important;
+	/* Legacy names (Firefox <= 151) */
+	--button-hover-bgcolor: var(--hover-color-primary) !important;
+	--toolbarbutton-active-background: var(--hover-color-primary) !important;
+	--toolbarbutton-inner-padding: 6px !important;
+
+	/* ----------------------------------------------------------------------
+	   URL bar geometry
+	   The address bar is a little shorter than default. Its inner controls
+	   are uniformly inset by --urlbar-inner-margin, so their corner radius
+	   follows the nested "distance formula" (inner = outer - margin) and
+	   stays concentric with the urlbar's own --border-circle corners.
+	   Control height is derived so the inset is equal on every side:
+	   height = urlbar-height - 2 * inner-margin.
+	   ---------------------------------------------------------------------- */
+	--urlbar-height: 30px;
+	--urlbar-inner-margin: 4px;
+	--urlbar-control-height: calc(var(--urlbar-height) - 2 * var(--urlbar-inner-margin));
+	--urlbar-inner-radius: max(0px, calc(var(--border-circle) - var(--urlbar-inner-margin)));
+
+	/* ----------------------------------------------------------------------
+	   URL bar colors
+	   ---------------------------------------------------------------------- */
+	--urlbar-solid-bg: #f2f2f2;
+	--urlbar-base-color: var(--mf-toolbar-bg);
+	--urlbar-overlay-active: color-mix(in srgb, var(--mf-toolbar-fg) 5%, transparent);
+	--urlbar-overlay-non-active: color-mix(in srgb, var(--mf-toolbar-fg) 9%, transparent);
+	--url-border-color: rgba(0, 0, 0, 0.15);
+	--url-placeholder-color: rgba(0, 0, 0, 0.5);
+	--url-bar-outline-color: AccentColor;
+	--toolbar-field-focus-color: AccentColor;
+
+	/* ----------------------------------------------------------------------
+	   Misc
+	   ---------------------------------------------------------------------- */
+	--fullscreen-color: #fafafa;
+}
+
+/* Enable Safari-like Tahoe UI when `userChrome.tahoeUI.enabled` is true in about:config */
+@media -moz-pref("userChrome.tahoeUI.enabled") {
+	:root {
+		--border-circle: 99px;
+		--border-big: 20px;
+		--border-big-2: 16px;
+	}
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--fullscreen-color: #2a2a2a;
+		--urlbar-solid-bg: #2b2b2b;
+		--url-border-color: rgba(255, 255, 255, 0.15);
+		--url-placeholder-color: rgba(255, 255, 255, 0.5);
+	}
+}
+
+/* If Firefox/ATBC provides a dynamic field color, prefer it. Must stay after
+   the base + dark definitions so it wins the cascade. */
+:root {
+	--urlbar-solid-bg: var(--toolbar-field-background-color, var(--urlbar-solid-bg));
+}


### PR DESCRIPTION
Firefox 152 renamed the toolbar and toolbarbutton custom properties, which broke the tab pill/border and toolbar-button styling. Fix with new names + legacy fallbacks, and reorganize the theme for maintainability.

- Add variables.css: single home for all custom properties
- Toolbar rename: --toolbar-bgcolor/-color -> --toolbar-background-color/ -text-color, unified into shared --mf-toolbar-bg/-fg aliases
- Toolbarbutton rename: --toolbarbutton-<prop>-<state> scheme with legacy fallbacks for Firefox <= 151
- URL bar: shorter (30px), larger uniform inset (4px), nested "distance formula" corner radius so inner controls stay concentric
- More top/bottom nav-bar padding
- Hide non-Nova New Tab personalize/customize button
- Disable tab hover preview pref documented in README
- Add install.sh to copy CSS into the profile chrome folder
- README updated for Firefox 153